### PR TITLE
do not use several site roots in multi domain environment

### DIFF
--- a/Classes/Controller/ViewController.php
+++ b/Classes/Controller/ViewController.php
@@ -134,8 +134,12 @@ class ViewController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
      */
     private function getPagesWithoutExcludes()
     {
-        $siteRoot = $this->viewRepository->getSiteRoot();
-        $pages = $this->getPages($siteRoot);
+        if ($GLOBALS['TSFE']->page['is_siteroot']) {
+            $siteRoots[] = array('uid' => $GLOBALS['TSFE']->id);
+        } else {
+            $siteRoots = $this->viewRepository->getSiteRoot();
+        }
+        $pages = $this->getPages($siteRoots);
 
         $newPages = array();
         foreach($pages as $page)


### PR DESCRIPTION
I am wondering about the use case having several site roots in a sitemap under a single base_url. For the standard multi domain case, using but a single site root per domain, one would have to define excludes on every domain. For five domains that means adding the exclude definition five times. Please pull or add a still more downward compatible solution.
